### PR TITLE
resolve main queue warning on iOS

### DIFF
--- a/ios/HmsManager.swift
+++ b/ios/HmsManager.swift
@@ -30,6 +30,10 @@ class HmsManager: RCTEventEmitter, HMSUpdateListener, HMSPreviewListener {
         }
     }
     
+    override class func requiresMainQueueSetup() -> Bool {
+        true
+    }
+    
     func on(join room: HMSRoom) {
         // Callback from join action
         let roomData = HmsDecoder.getHmsRoom(room)

--- a/ios/HmsView.swift
+++ b/ios/HmsView.swift
@@ -16,6 +16,10 @@ class HmsView: RCTViewManager {
     func getHmsFromBridge() -> HMSSDK? {
         return (bridge.module(for: HmsManager.classForCoder()) as? HmsManager)?.hms
     }
+    
+    override class func requiresMainQueueSetup() -> Bool {
+        true
+    }
 }
 
 class HmssdkDisplayView: UIView {


### PR DESCRIPTION
Added to resolve this warning
```
Module HmsManager requires main queue setup since it overrides `init` but doesn't implement `requiresMainQueueSetup`. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.
[Wed Sep 29 2021 19:49:35.620]  WARN     Module HmsView requires main queue setup since it overrides `init` but doesn't implement `requiresMainQueueSetup`. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of
```