### PR TITLE
Remote peers not visible in room

### DIFF
--- a/example/src/screens/QRCode/index.tsx
+++ b/example/src/screens/QRCode/index.tsx
@@ -14,7 +14,7 @@ import type {NativeStackNavigationProp} from '@react-navigation/native-stack';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
 import MaterialIcons from 'react-native-vector-icons/MaterialIcons';
-import {useDispatch, useSelector} from 'react-redux';
+import {useDispatch} from 'react-redux';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 import type {AppStackParamList} from '../../navigator';
@@ -28,7 +28,6 @@ import {
   JoinSettingsModalContent,
 } from '../../components';
 import {saveUserData} from '../../redux/actions';
-import type {RootState} from '../../redux';
 import {Constants} from '../../utils/types';
 
 type QRCodeScreenProp = NativeStackNavigationProp<
@@ -38,13 +37,11 @@ type QRCodeScreenProp = NativeStackNavigationProp<
 
 const QRCode = () => {
   const navigate = useNavigation<QRCodeScreenProp>().navigate;
-  const {isHLSFlow} = useSelector((state: RootState) => state.user);
   const {top, bottom, left, right} = useSafeAreaInsets();
   const dispatch = useDispatch();
 
   const [joinDisabled, setJoinDisabled] = useState<boolean>(true);
   const [joiningLink, setJoiningLink] = useState<string>(getMeetingUrl());
-  const [isHLSFlowEnabled, setIsHLSFlowEnabled] = useState<boolean>(isHLSFlow);
   const [moreModalVisible, setMoreModalVisible] = useState(false);
 
   const onJoinPress = () => {
@@ -52,7 +49,7 @@ const QRCode = () => {
       dispatch(
         saveUserData({
           roomID: joiningLink.replace('meeting', 'preview'),
-          isHLSFlow: isHLSFlowEnabled,
+          isHLSFlow: true,
         }),
       );
       navigate('WelcomeScreen');
@@ -134,26 +131,6 @@ const QRCode = () => {
         </View>
         <View style={styles.joiningLinkInputView}>
           <Text style={styles.joiningLinkInputText}>Joining Link</Text>
-          <View style={styles.joiningFlowContainer}>
-            <CustomButton
-              title="Meeting"
-              onPress={() => setIsHLSFlowEnabled(false)}
-              viewStyle={[
-                styles.joiningFlowLeft,
-                !isHLSFlowEnabled && styles.selectedFlow,
-              ]}
-              textStyle={[styles.joiningLinkInputText]}
-            />
-            <CustomButton
-              title="HLS"
-              onPress={() => setIsHLSFlowEnabled(true)}
-              viewStyle={[
-                styles.joiningFlowRight,
-                isHLSFlowEnabled && styles.selectedFlow,
-              ]}
-              textStyle={[styles.joiningLinkInputText]}
-            />
-          </View>
         </View>
         <CustomInput
           value={joiningLink}

--- a/example/src/screens/Welcome/index.tsx
+++ b/example/src/screens/Welcome/index.tsx
@@ -123,7 +123,7 @@ const Welcome = () => {
       data.room.localPeer,
       data.room.localPeer.videoTrack,
     );
-    dispatch(setPeerState({peerState: [hmsLocalPeer]}));
+    dispatch(setPeerState({peerState: [hmsLocalPeer, ...peerTrackNodesRef.current]}));
     AsyncStorage.setItem(
       Constants.MEET_URL,
       roomID.replace('preview', 'meeting'),

--- a/example/src/utils/functions.ts
+++ b/example/src/utils/functions.ts
@@ -727,8 +727,10 @@ export const getDisplayTrackDimensions = (
   orientation: boolean,
 ) => {
   // window height - (header + footer + top + bottom + padding)
+
+  // Using "extra offset" (i.e. 32) for android as we are getting wrong window height
   const viewHeight =
-    Dimensions.get('window').height - (50 + 50 + top + bottom + 2);
+    Dimensions.get('window').height - (50 + 50 + top + bottom + (Platform.OS === 'android' ? 32 : 2));
 
   let height, width;
 


### PR DESCRIPTION
closes #835 

1. Fixes:
    - earlier joined Remote peers not visible in room issue
    - Peer Tile height issue on android


2. Removed "Meeting" flow button from QRCode screen

