### PR TITLE
Undefined Role encoding

### DIFF
--- a/src/classes/HMSEncoder.ts
+++ b/src/classes/HMSEncoder.ts
@@ -373,6 +373,10 @@ export class HMSEncoder {
   }
 
   static encodeHmsRole(role: any) {
+    if (!role) {
+      return new HMSRole(role);
+    }
+
     const rolesCache = this.data.roles;
 
     const cachedRole = rolesCache[role.name];


### PR DESCRIPTION
app was crashing when undefined is passed to `encodeHmsRole` method