### PR TITLE
Restricting HMSRole data from native side

### DIFF
--- a/android/src/main/java/com/reactnativehmssdk/HMSDecoder.kt
+++ b/android/src/main/java/com/reactnativehmssdk/HMSDecoder.kt
@@ -13,6 +13,15 @@ import live.hms.video.sdk.models.role.*
 import live.hms.video.sdk.models.trackchangerequest.HMSChangeTrackStateRequest
 
 object HMSDecoder {
+  private var restrictRoleData = mutableMapOf<String, Boolean>()
+
+  fun setRestrictRoleData(roleName: String, value: Boolean) {
+    this.restrictRoleData[roleName] = value
+  }
+
+  fun clearRestrictDataStates() {
+    this.restrictRoleData.clear()
+  }
 
   fun getHmsRoom(hmsRoom: HMSRoom?): WritableMap {
     val room: WritableMap = Arguments.createMap()
@@ -149,15 +158,17 @@ object HMSDecoder {
     val role: WritableMap = Arguments.createMap()
     if (hmsRole != null) {
       role.putString("name", hmsRole.name)
-      role.putMap("permissions", this.getHmsPermissions(hmsRole.permission))
-      hmsRole.publishParams?.let {
-        role.putMap("publishSettings", this.getHmsPublishSettings(it))
-      }
-      hmsRole.subscribeParams?.let {
-        role.putMap("subscribeSettings", this.getHmsSubscribeSettings(it))
-      }
+      if (this.restrictRoleData[hmsRole.name] != true) {
+        role.putMap("permissions", this.getHmsPermissions(hmsRole.permission))
+        hmsRole.publishParams?.let {
+          role.putMap("publishSettings", this.getHmsPublishSettings(it))
+        }
+        hmsRole.subscribeParams?.let {
+          role.putMap("subscribeSettings", this.getHmsSubscribeSettings(it))
+        }
 
-      role.putInt("priority", hmsRole.priority)
+        role.putInt("priority", hmsRole.priority)
+      }
     }
     return role
   }

--- a/android/src/main/java/com/reactnativehmssdk/HMSManager.kt
+++ b/android/src/main/java/com/reactnativehmssdk/HMSManager.kt
@@ -450,6 +450,13 @@ class HMSManager(reactContext: ReactApplicationContext) :
     hms?.getSessionMetaData(callback)
   }
 
+  @ReactMethod()
+  fun restrictData(data: ReadableMap, promise: Promise?) {
+    val hms = HMSHelper.getHms(data, hmsCollection)
+
+    hms?.restrictData(data, promise)
+  }
+
   // region Person-In-Person Mode Action handing
   private val pipReceiver by lazy {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {

--- a/android/src/main/java/com/reactnativehmssdk/HMSRNSDK.kt
+++ b/android/src/main/java/com/reactnativehmssdk/HMSRNSDK.kt
@@ -1474,7 +1474,7 @@ class HMSRNSDK(
         HMSDecoder.setRestrictRoleData(roleName, true)
       }
     } else {
-      val errorMessage = "t: $requiredKeys"
+      val errorMessage = "restrictData: $requiredKeys"
       self.emitRequiredKeysError(errorMessage)
       rejectCallback(promise, errorMessage)
     }

--- a/android/src/main/java/com/reactnativehmssdk/HMSRNSDK.kt
+++ b/android/src/main/java/com/reactnativehmssdk/HMSRNSDK.kt
@@ -1472,6 +1472,7 @@ class HMSRNSDK(
       val roleName = data.getString("roleName")
       if (roleName != null) {
         HMSDecoder.setRestrictRoleData(roleName, true)
+        promise?.resolve(emitHMSSuccess())
       }
     } else {
       val errorMessage = "restrictData: $requiredKeys"

--- a/android/src/main/java/com/reactnativehmssdk/HMSRNSDK.kt
+++ b/android/src/main/java/com/reactnativehmssdk/HMSRNSDK.kt
@@ -228,7 +228,7 @@ class HMSRNSDK(
 
               override fun onRemovedFromRoom(notification: HMSRemovedFromRoom) {
                 super.onRemovedFromRoom(notification)
-
+                HMSDecoder.clearRestrictDataStates()
                 val data: WritableMap = Arguments.createMap()
                 val requestedBy =
                   HMSDecoder.getHmsRemotePeer(notification.peerWhoRemoved as HMSRemotePeer?)
@@ -521,6 +521,7 @@ class HMSRNSDK(
             audioshareCallback = null
             networkQualityUpdatesAttached = false
             rtcStatsAttached = false
+            HMSDecoder.clearRestrictDataStates()
             if (fromPIP) {
               context.currentActivity?.moveTaskToBack(false)
 
@@ -1462,5 +1463,20 @@ class HMSRNSDK(
         }
       }
     )
+  }
+
+  fun restrictData(data: ReadableMap, promise: Promise?) {
+    val requiredKeys =
+      HMSHelper.getUnavailableRequiredKey(data, arrayOf(Pair("roleName", "String")))
+    if (requiredKeys === null) {
+      val roleName = data.getString("roleName")
+      if (roleName != null) {
+        HMSDecoder.setRestrictRoleData(roleName, true)
+      }
+    } else {
+      val errorMessage = "t: $requiredKeys"
+      self.emitRequiredKeysError(errorMessage)
+      rejectCallback(promise, errorMessage)
+    }
   }
 }

--- a/ios/HMSDecoder.swift
+++ b/ios/HMSDecoder.swift
@@ -2,6 +2,16 @@ import HMSSDK
 import Foundation
 
 class HMSDecoder: NSObject {
+    static private var restrictRoleData: [String: Bool] = [:]
+
+    static func setRestrictRoleData (_ roleName: String, _ value: Bool) {
+        restrictRoleData[roleName] = value
+    }
+
+    static func clearRestrictDataStates () {
+        restrictRoleData.removeAll()
+    }
+
     static func getHmsRoom (_ hmsRoom: HMSRoom?) -> [String: Any] {
 
         guard let room = hmsRoom else { return [String: Any]() }
@@ -337,6 +347,11 @@ class HMSDecoder: NSObject {
         guard let role = hmsRole else { return [String: Any]() }
 
         let name = role.name
+
+        if restrictRoleData[role.name] == true {
+            return ["name": name]
+        }
+
         let permissions = getHmsPermissions(role.permissions)
         let publishSettings = getHmsPublishSettings(role.publishSettings)
         let subscribeSettings = getHmsSubscribeSettings(role.subscribeSettings)

--- a/ios/HMSManager.m
+++ b/ios/HMSManager.m
@@ -57,4 +57,5 @@ RCT_EXTERN_METHOD(setSessionMetaData: (NSDictionary) data :(RCTPromiseResolveBlo
 RCT_EXTERN_METHOD(getSessionMetaData: (NSDictionary) data :(RCTPromiseResolveBlock) resolve :(RCTPromiseRejectBlock) reject)
 RCT_EXTERN_METHOD(changeRoleOfPeer: (NSDictionary) data :(RCTPromiseResolveBlock) resolve :(RCTPromiseRejectBlock) reject)
 RCT_EXTERN_METHOD(changeRoleOfPeersWithRoles: (NSDictionary) data :(RCTPromiseResolveBlock) resolve :(RCTPromiseRejectBlock) reject)
+RCT_EXTERN_METHOD(restrictData: (NSDictionary) data :(RCTPromiseResolveBlock) resolve :(RCTPromiseRejectBlock) reject)
 @end

--- a/ios/HMSManager.swift
+++ b/ios/HMSManager.swift
@@ -401,6 +401,13 @@ class HMSManager: RCTEventEmitter {
         hms?.setSessionMetaData(data, resolve, reject)
     }
 
+    @objc
+    func restrictData(_ data: NSDictionary, _ resolve: RCTPromiseResolveBlock?, _ reject: RCTPromiseRejectBlock?) {
+        let hms = HMSHelper.getHms(data, hmsCollection)
+
+        hms?.restrictData(data, resolve, reject)
+    }
+
     // MARK: - HMS SDK Get APIs
     @objc
     func getRoom(_ data: NSDictionary, _ resolve: RCTPromiseResolveBlock?, _ reject: RCTPromiseRejectBlock?) {

--- a/ios/HMSRNSDK.swift
+++ b/ios/HMSRNSDK.swift
@@ -211,6 +211,7 @@ class HMSRNSDK: HMSUpdateListener, HMSPreviewListener {
                 self?.networkQualityUpdatesAttached = false
                 self?.hms?.leave({ success, error in
                     if success {
+                        HMSDecoder.clearRestrictDataStates()
                         resolve?(["success": success])
                     } else {
                         strongSelf.delegate?.emitEvent(strongSelf.ON_ERROR, ["error": HMSDecoder.getError(error), "id": strongSelf.id])
@@ -1024,6 +1025,18 @@ class HMSRNSDK: HMSUpdateListener, HMSPreviewListener {
         }
     }
 
+    func restrictData(_ data: NSDictionary, _ resolve: RCTPromiseResolveBlock?, _ reject: RCTPromiseRejectBlock?) {
+        guard let roleName = data.value(forKey: "roleName") as? String else {
+            let errorMessage = "restrictData: " + HMSHelper.getUnavailableRequiredKey(data, ["roleName"])
+            emitRequiredKeysError(errorMessage)
+            reject?(errorMessage, errorMessage, nil)
+            return
+        }
+
+        HMSDecoder.setRestrictRoleData(roleName, true)
+        resolve?(["success": true, "message": "function call executed successfully"])
+    }
+
     // MARK: - HMS SDK Get APIs
     func getRoom(_ resolve: RCTPromiseResolveBlock?) {
         let roomData = HMSDecoder.getHmsRoom(hms?.room)
@@ -1158,6 +1171,7 @@ class HMSRNSDK: HMSUpdateListener, HMSPreviewListener {
     }
 
     func on(removedFromRoom notification: HMSRemovedFromRoomNotification) {
+        HMSDecoder.clearRestrictDataStates()
         let requestedBy = notification.requestedBy as HMSPeer?
         var decodedRequestedBy: [String: Any]?
         if let requested = requestedBy {


### PR DESCRIPTION
when JS side has HMSRole data, there is no need to send it from Native side.

**Check Role based functionalities - This is a breaking change**
