### PR TITLE
Reduced new object creation in HMSPeerCache

### DIFF
--- a/android/src/main/java/com/reactnativehmssdk/HMSDecoder.kt
+++ b/android/src/main/java/com/reactnativehmssdk/HMSDecoder.kt
@@ -130,23 +130,22 @@ object HMSDecoder {
     if (hmsPeer != null) {
       peer.putString(peerUpdateType.ordinal.toString(), hmsPeer.peerID)
 
-      if (peerUpdateType !== null) {
-        when (peerUpdateType) {
-          HMSPeerUpdate.NAME_CHANGED -> {
-            peer.putString("name", hmsPeer.name)
-          }
-          HMSPeerUpdate.METADATA_CHANGED -> {
-            peer.putString("metadata", hmsPeer.metadata)
-          }
-          HMSPeerUpdate.ROLE_CHANGED -> {
-            peer.putMap("role", this.getHmsRole(hmsPeer.hmsRole))
-          }
-          HMSPeerUpdate.NETWORK_QUALITY_UPDATED -> {
-            hmsPeer.networkQuality?.let {
-              peer.putMap("networkQuality", this.getHmsNetworkQuality(it))
-            }
+      when (peerUpdateType) {
+        HMSPeerUpdate.NAME_CHANGED -> {
+          peer.putString("name", hmsPeer.name)
+        }
+        HMSPeerUpdate.METADATA_CHANGED -> {
+          peer.putString("metadata", hmsPeer.metadata)
+        }
+        HMSPeerUpdate.ROLE_CHANGED -> {
+          peer.putMap("role", this.getHmsRole(hmsPeer.hmsRole))
+        }
+        HMSPeerUpdate.NETWORK_QUALITY_UPDATED -> {
+          hmsPeer.networkQuality?.let {
+            peer.putMap("networkQuality", this.getHmsNetworkQuality(it))
           }
         }
+        else -> {}
       }
     }
     return peer

--- a/src/classes/HMSEncoder.ts
+++ b/src/classes/HMSEncoder.ts
@@ -95,7 +95,6 @@ export class HMSEncoder {
   static encodeHmsPeer(peer: any) {
     const encodedObj = {
       peerID: peer?.peerID,
-      customerDescription: peer?.customerDescription || undefined,
     };
 
     return new HMSPeer(encodedObj);
@@ -156,7 +155,6 @@ export class HMSEncoder {
   static encodeHmsLocalPeer(peer: any, id: string) {
     const encodedObj = {
       peerID: peer?.peerID,
-      customerDescription: peer?.customerDescription || undefined,
       localAudioTrackData: peer?.localAudioTrackData?.trackId
         ? {
             id: id,
@@ -270,7 +268,6 @@ export class HMSEncoder {
   static encodeHmsRemotePeer(peer: any, id: string) {
     const encodedObj = {
       peerID: peer?.peerID,
-      customerDescription: peer.customerDescription,
       remoteAudioTrackData: peer?.remoteAudioTrackData?.trackId
         ? {
             id: id,

--- a/src/classes/HMSLocalPeer.ts
+++ b/src/classes/HMSLocalPeer.ts
@@ -18,7 +18,6 @@ export class HMSLocalPeer extends HMSPeer {
 
   constructor(params: {
     peerID: string;
-    customerDescription?: string;
     localAudioTrackData?: {
       id: string;
       trackId: string;

--- a/src/classes/HMSPeer.ts
+++ b/src/classes/HMSPeer.ts
@@ -8,14 +8,9 @@ import { HMSConstants } from './HMSConstants';
 
 export class HMSPeer {
   peerID: string;
-  /**
-   * @deprecated customerDescription property has been deprecated in favor of metadata property
-   */
-  customerDescription?: string;
 
-  constructor(params: { peerID: string; customerDescription?: string }) {
+  constructor(params: { peerID: string }) {
     this.peerID = params.peerID;
-    this.customerDescription = params.customerDescription;
   }
 
   get name(): string {

--- a/src/classes/HMSRemotePeer.ts
+++ b/src/classes/HMSRemotePeer.ts
@@ -16,7 +16,6 @@ export class HMSRemotePeer extends HMSPeer {
 
   constructor(params: {
     peerID: string;
-    customerDescription?: string;
     remoteAudioTrackData?: {
       trackId: string;
       source?: number | string;


### PR DESCRIPTION
Changes to reduce the number of objects created to update HMSPeersCache. These objects were created unnecessarily and were garbage collected. This change will reduce memory consumption in large rooms