### PR TITLE
Release 1.7.1: Added support to Not mute local peer when incoming phone call is ringing 

### DIFF
--- a/android/src/main/java/com/reactnativehmssdk/HMSHelper.kt
+++ b/android/src/main/java/com/reactnativehmssdk/HMSHelper.kt
@@ -236,6 +236,7 @@ object HMSHelper {
       }
     }
 
+    // TODO: check if audio & video track settings get applied even if client apps do not pass any values?
     if (this.areAllRequiredKeysAvailable(data, arrayOf(Pair("audio", "Map")))) {
       val audio = data.getMap("audio")
       val audioSettings = this.getAudioTrackSettings(audio)
@@ -251,6 +252,7 @@ object HMSHelper {
       return null
     }
     val builder = HMSAudioTrackSettings.Builder()
+
     if (areAllRequiredKeysAvailable(data, arrayOf(Pair("useHardwareEchoCancellation", "Boolean")))
     ) {
       val useHardwareEchoCancellation = data.getBoolean("useHardwareEchoCancellation")
@@ -263,6 +265,9 @@ object HMSHelper {
       val initialState = getHMSTrackSettingsInitState(data.getString("initialState"))
       builder.initialState(initialState)
     }
+
+    builder.setPhoneCallMuteState(PhoneCallState.DISABLE_MUTE_ON_VOIP_PHONE_CALL_RING)
+
     return builder.build()
   }
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -290,7 +290,7 @@ PODS:
     - React-Core
   - react-native-document-picker (8.2.1):
     - React-Core
-  - react-native-hms (1.7.0):
+  - react-native-hms (1.7.1):
     - HMSBroadcastExtensionSDK (= 0.0.9)
     - HMSHLSPlayerSDK (= 0.0.2)
     - HMSSDK (= 0.9.5)
@@ -608,7 +608,7 @@ SPEC CHECKSUMS:
   React-jsinspector: d4f6973dd474357dbaaf6f52f31ffc713bf3e766
   react-native-camera: 3eae183c1d111103963f3dd913b65d01aef8110f
   react-native-document-picker: 69ca2094d8780cfc1e7e613894d15290fdc54bba
-  react-native-hms: 11cdcbdf17424584f0409484567ecc9c7c4a66d5
+  react-native-hms: 5727f27f8b112168394ba75b13e18137f6235d17
   react-native-safe-area-context: 9e40fb181dac02619414ba1294d6c2a807056ab9
   react-native-simple-toast: 8ee5d23f0b92b935ab7434cdb65159ce12dfb4b7
   React-perflogger: 5a890ca0911669421b7611661e9b58f91c805f5c

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "RNHMSExample",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "RNHMSExample",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "hasInstallScript": true,
       "dependencies": {
         "@miblanchard/react-native-slider": "^2.0.2",

--- a/example/package.json
+++ b/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "RNHMSExample",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "private": true,
   "scripts": {
     "preinstall": "cd ../ && npm install && cd ./example",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@100mslive/react-native-hms",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@100mslive/react-native-hms",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "MIT",
       "dependencies": {
         "zustand": "^4.3.8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@100mslive/react-native-hms",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Integrate Real Time Audio and Video conferencing, Interactive Live Streaming, and Chat in your apps with 100ms React Native SDK. With support for HLS and RTMP Live Streaming and Recording, Picture-in-Picture (PiP), one-to-one Video Call Modes, Audio Rooms, Video Player and much more, add immersive real-time communications to your apps.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/sdk-versions.json
+++ b/sdk-versions.json
@@ -2,5 +2,5 @@
   "ios": "0.9.5",
   "iOSBroadcastExtension": "0.0.9",
   "iOSHMSHLSPlayer": "0.0.2",
-  "android": "2.6.7"
+  "android": "2.6.8"
 }


### PR DESCRIPTION
# Description

- [ ] Added option to NOT mute when the phone is in ringing state. 
- [x] By default, the local peer will not be muted when phone call is ringing. 

### Pre-launch Checklist

- [ ] The [Documentation] is updated accordingly, or this PR doesn't require it.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making, or this PR is test-exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Documentation]: https://www.100ms.live/docs
